### PR TITLE
feat(admin): Add duplicate question prevention

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -8,6 +8,7 @@ import socraticTutorRouter from "./routes/socraticTutor.js";
 import generateMcqRouter from "./routes/generateMcq.js";
 import generateTheoryRouter from "./routes/generateTheory.js";
 import extractQuestionsRouter from "./routes/extractQuestions.js";
+import saveQuestionsRouter from "./routes/saveQuestions.js";
 import { initializeApp } from "firebase-admin/app";
 import { getFirestore } from "firebase-admin/firestore";
 
@@ -41,6 +42,7 @@ app.use("/chat", socraticTutorRouter);
 app.use("/generate-mcq-test", generateMcqRouter);
 app.use("/generate-theory-test", generateTheoryRouter);
 app.use("/extract-questions", extractQuestionsRouter);
+app.use("/save-questions", saveQuestionsRouter);
 
 // ---------- Global error handler (JSON always) ----------
 app.use((err, req, res, _next) => {

--- a/functions/routes/saveQuestions.js
+++ b/functions/routes/saveQuestions.js
@@ -1,0 +1,63 @@
+import express from "express";
+// ✅ **FIX**: Only import getFirestore, as the other functions are not part of the Admin SDK
+import { getFirestore } from "firebase-admin/firestore";
+
+const router = express.Router();
+
+router.post("/", express.json(), async (req, res) => {
+    const db = getFirestore();
+    try {
+        const { questions, metadata } = req.body;
+        const uid = req.auth?.uid;
+
+        if (!questions || !metadata || !Array.isArray(questions)) {
+            return res.status(400).json({ error: "Invalid request body." });
+        }
+
+        const questionBankRef = db.collection("questionBank"); // ✅ **FIX**: Use Admin SDK syntax
+        const batch = db.batch(); // ✅ **FIX**: Use Admin SDK syntax
+        let addedCount = 0;
+        let existingCount = 0;
+
+        await Promise.all(questions.map(async (question) => {
+            // ✅ **FIX**: Rewrote the query using the chained Admin SDK syntax
+            const q = questionBankRef
+                .where("questionText", "==", question.questionText)
+                .where("exam", "==", metadata.exam)
+                .where("year", "==", metadata.year)
+                .where("paper", "==", metadata.paper);
+
+            const querySnapshot = await q.get();
+
+            if (querySnapshot.empty) {
+                const newQuestionRef = questionBankRef.doc();
+                const dataToSave = {
+                    ...question,
+                    ...metadata,
+                    topic: question.topic.replace(/\s/g, ''),
+                    createdAt: new Date(),
+                    uploaderId: uid || 'admin-user',
+                };
+                batch.set(newQuestionRef, dataToSave);
+                addedCount++;
+            } else {
+                existingCount++;
+            }
+        }));
+
+        await batch.commit();
+
+        res.status(200).json({
+            message: "Save operation completed.",
+            totalQuestionsReceived: questions.length,
+            newQuestionsAdded: addedCount,
+            duplicatesSkipped: existingCount,
+        });
+
+    } catch (error) {
+        console.error("Error saving questions:", error);
+        res.status(500).json({ error: "An error occurred while saving questions." });
+    }
+});
+
+export default router;


### PR DESCRIPTION
Implement a backend endpoint (/save-questions) that checks for existing questions in Firestore before saving. This prevents duplicate entries in the questionBank collection. The frontend now calls this endpoint instead of writing directly to the database.